### PR TITLE
Sprint3/2941

### DIFF
--- a/lib/middleware/UsuarioBD.dart
+++ b/lib/middleware/UsuarioBD.dart
@@ -48,7 +48,8 @@ class UsuarioBD {
 
   static Widget _obtenerListadoUsuarios(BuildContext context,
       AsyncSnapshot<QuerySnapshot> snapshot, Function(Usuario) onSelected) {
-    if (!snapshot.hasData) return const Center(child: const CircularProgressIndicator());
+    if (!snapshot.hasData)
+      return const Center(child: const CircularProgressIndicator());
 
     var usuarios = snapshot.data.documents;
 
@@ -84,10 +85,9 @@ class UsuarioBD {
         .createUserWithEmailAndPassword(email: correo, password: password);
   }
 
-  static Future<Usuario> obtenerUsuarioActual() => FirebaseAuth.instance
-      .currentUser()
-      .then((firebaseUser) => 
-      firebaseUser == null ? null : obtenerUsuarioConUid(firebaseUser.uid));
+  static Future<Usuario> obtenerUsuarioActual() =>
+      FirebaseAuth.instance.currentUser().then((firebaseUser) =>
+          firebaseUser == null ? null : obtenerUsuarioConUid(firebaseUser.uid));
 
   static Future<Usuario> obtenerUsuarioConUid(String uid) {
     return Datos.obtenerColeccion(coleccion_usuarios)
@@ -112,4 +112,9 @@ class UsuarioBD {
       FirebaseAuth.instance.signInWithCredential(credential);
 
   static Future<void> signOut() => FirebaseAuth.instance.signOut();
+
+  static Future<bool> existeUsuarioConNickname(String nickname) =>
+      Datos.obtenerColeccion(coleccion_usuarios).getDocuments().then((query) =>
+          query.documents
+              .any((snapshot) => obtenerNickname(snapshot) == nickname));
 }

--- a/lib/vistas/inicio/Authentication/registrarse/Registrarse.dart
+++ b/lib/vistas/inicio/Authentication/registrarse/Registrarse.dart
@@ -26,6 +26,9 @@ class RegistrarseState extends State<Registrarse> {
   final TextEditingController _ageController = TextEditingController();
   String _ciudad;
 
+  bool nicknameRepetido = false;
+  String ultimoNicknameComprobado;
+
   @override
   Widget build(BuildContext context) {
     return Form(
@@ -61,6 +64,9 @@ class RegistrarseState extends State<Registrarse> {
                     validator: (value) {
                       if (value.isEmpty) {
                         return 'El valor no puede estar vacío';
+                      }
+                      if (nicknameRepetido) {
+                        return 'Este nombre de usuario ya está en uso. Escoge otro';
                       }
                       return null;
                     },
@@ -202,6 +208,17 @@ class RegistrarseState extends State<Registrarse> {
                         borderRadius: BorderRadius.all(Radius.circular(10.0)),
                       ),
                       onPressed: () async {
+                        String nuevoNickname = _nicknameController.text;
+                        if (ultimoNicknameComprobado == null ||
+                            ultimoNicknameComprobado != nuevoNickname) {
+                          nicknameRepetido =
+                              await UsuarioBD.existeUsuarioConNickname(
+                                  nuevoNickname);
+
+                          // Guardando el ultimo comprobado evitamos llamar a la base de datos más de la cuenta mediante spamming
+                          ultimoNicknameComprobado = nuevoNickname;
+                        }
+
                         if (_formKey.currentState.validate()) {
                           if (await UsuarioBD.existeUsuarioConNickname(
                               _nicknameController.text)) {

--- a/lib/vistas/inicio/Authentication/registrarse/Registrarse.dart
+++ b/lib/vistas/inicio/Authentication/registrarse/Registrarse.dart
@@ -131,7 +131,7 @@ class RegistrarseState extends State<Registrarse> {
                         return 'El valor no puede estar vacío';
                       }
                       if (value.length < 6) {
-                        return 'La contraseña debe tener mas de 6 carácteres';
+                        return 'La contraseña debe tener más de 6 caracteres';
                       }
                       return null;
                     },
@@ -184,7 +184,7 @@ class RegistrarseState extends State<Registrarse> {
                         return 'El valor no puede estar vacío';
                       }
                       if (soloNumeros < 18 || soloNumeros > 99) {
-                        return 'Edad incorrecta';
+                        return 'Edad incorrecta. Debe ser mayor de edad (18+)';
                       }
                       return null;
                     },

--- a/lib/vistas/inicio/Authentication/registrarse/Registrarse.dart
+++ b/lib/vistas/inicio/Authentication/registrarse/Registrarse.dart
@@ -3,6 +3,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:toast/toast.dart';
+import 'package:transportify/middleware/UsuarioBD.dart';
 import 'package:transportify/modelos/Usuario.dart';
 import 'package:transportify/util/style.dart';
 import 'package:transportify/vistas/dialog/CiudadDialog.dart';
@@ -64,9 +65,9 @@ class RegistrarseState extends State<Registrarse> {
                       return null;
                     },
                     decoration: InputDecoration(
-                      icon: Icon(Icons.person),
-                      hintText: 'Introduce nickname',
-                      labelText: 'Nickname',
+                      icon: Icon(Icons.person_outline),
+                      hintText: 'Introduce un nombre de usuario',
+                      labelText: 'Nombre de usuario',
                     ),
                   ),
                   TextFormField(
@@ -202,8 +203,18 @@ class RegistrarseState extends State<Registrarse> {
                       ),
                       onPressed: () async {
                         if (_formKey.currentState.validate()) {
-                          FocusScope.of(context).requestFocus(new FocusNode());
-                          _register();
+                          if (await UsuarioBD.existeUsuarioConNickname(
+                              _nicknameController.text)) {
+                            Toast.show(
+                                "Error: El nombre de usuario está en uso. Elija otro.",
+                                context,
+                                duration: Toast.LENGTH_LONG,
+                                gravity: Toast.BOTTOM);
+                          } else {
+                            FocusScope.of(context)
+                                .requestFocus(new FocusNode());
+                            _register();
+                          }
                         }
                       },
                       child: Text(
@@ -229,7 +240,6 @@ class RegistrarseState extends State<Registrarse> {
     super.dispose();
   }
 
-  // Example code for registration.
   void _register() async {
     try {
       Usuario usuario = new Usuario(
@@ -244,7 +254,7 @@ class RegistrarseState extends State<Registrarse> {
       try {
         await usuario.crearEnBD();
         Toast.show("Usuario creado con éxito.", context,
-          duration: Toast.LENGTH_LONG, gravity: Toast.BOTTOM);
+            duration: Toast.LENGTH_LONG, gravity: Toast.BOTTOM);
         Navigator.pop(context);
       } on PlatformException catch (error) {
         print(error);

--- a/lib/vistas/inicio/Authentication/registrarse/Registrarse.dart
+++ b/lib/vistas/inicio/Authentication/registrarse/Registrarse.dart
@@ -220,18 +220,8 @@ class RegistrarseState extends State<Registrarse> {
                         }
 
                         if (_formKey.currentState.validate()) {
-                          if (await UsuarioBD.existeUsuarioConNickname(
-                              _nicknameController.text)) {
-                            Toast.show(
-                                "Error: El nombre de usuario está en uso. Elija otro.",
-                                context,
-                                duration: Toast.LENGTH_LONG,
-                                gravity: Toast.BOTTOM);
-                          } else {
-                            FocusScope.of(context)
-                                .requestFocus(new FocusNode());
-                            _register();
-                          }
+                          FocusScope.of(context).requestFocus(new FocusNode());
+                          _register();
                         }
                       },
                       child: Text(

--- a/lib/vistas/perfil/PerfilUsuarioView.dart
+++ b/lib/vistas/perfil/PerfilUsuarioView.dart
@@ -290,14 +290,6 @@ class PerfilUsuarioViewState extends State<PerfilUsuarioView> {
                     MaterialPageRoute<Null>(builder: (BuildContext context) {
                   return new IniciarSesionView();
                 }));
-
-                /*
-                                            Navigator.pushAndRemoveUntil(
-                                            context,
-                                            MaterialPageRoute(builder: (context) => IniciarSesionView()),
-                                            (Route<dynamic> route) => false,
-                                            );
-                                            */
               },
             ),
             new FlatButton(
@@ -333,7 +325,8 @@ class PerfilUsuarioViewState extends State<PerfilUsuarioView> {
     super.initState();
     nombreText.text = widget.usuario.nombre;
     nicknameText.text = widget.usuario.nickname;
-    ultimoNicknameComprobado = widget.usuario.nickname; // El que tiene ya cuenta como comprobado; sabemos que es correcto
+    ultimoNicknameComprobado = widget.usuario
+        .nickname; // El que tiene ya cuenta como comprobado; sabemos que es correcto
     ciudadText.text = widget.usuario.ciudad;
     edadText.text = widget.usuario.edad.toString();
   }

--- a/lib/vistas/perfil/PerfilUsuarioView.dart
+++ b/lib/vistas/perfil/PerfilUsuarioView.dart
@@ -164,7 +164,7 @@ class PerfilUsuarioViewState extends State<PerfilUsuarioView> {
                         return 'El valor no puede estar vacío';
                       }
                       if (soloNumeros < 18 || soloNumeros > 99) {
-                        return 'Edad incorrecta';
+                        return 'Edad incorrecta. Debe ser mayor de edad (18+)';
                       }
                       return null;
                     },

--- a/lib/vistas/perfil/PerfilUsuarioView.dart
+++ b/lib/vistas/perfil/PerfilUsuarioView.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:toast/toast.dart';
+import 'package:transportify/middleware/UsuarioBD.dart';
 import 'package:transportify/modelos/Usuario.dart';
 import 'package:transportify/util/style.dart';
 import 'package:transportify/vistas/inicio/Authentication/iniciarSesion/iniciarSesion.dart';
@@ -12,11 +14,9 @@ class PerfilUsuarioView extends StatefulWidget {
   PerfilUsuarioView(this.usuario) : super();
 
   final Usuario usuario;
-
 }
 
 class PerfilUsuarioViewState extends State<PerfilUsuarioView> {
-  
   final _formKey = GlobalKey<FormState>();
 
   bool editable = false;
@@ -27,14 +27,13 @@ class PerfilUsuarioViewState extends State<PerfilUsuarioView> {
 
   String ciudad;
 
-  var nombreApellidosText = TextEditingController();
-  var correoText = TextEditingController();
+  var nombreText = TextEditingController();
+  var nicknameText = TextEditingController();
   var ciudadText = TextEditingController();
   var edadText = TextEditingController();
 
   @override
   Widget build(BuildContext context) {
-    
     return Form(
       key: _formKey,
       child: Scaffold(
@@ -49,27 +48,26 @@ class PerfilUsuarioViewState extends State<PerfilUsuarioView> {
               color: colorEditar,
               onPressed: () {
                 setState(() {
-                cambiarColorEditable();
-                editable = !editable;
+                  cambiarColorEditable();
+                  editable = !editable;
                 });
               },
             ),
           ],
         ),
-          backgroundColor: Colors.grey[200],
-          body: Padding(
-            padding: EdgeInsets.only(left:15.0, right: 15.0, bottom: 30.0, top: 15.0),
-            child: Container (
-              child: SingleChildScrollView(
-                child: Column(
-                children: <Widget> [
-
+        backgroundColor: Colors.grey[200],
+        body: Padding(
+          padding:
+              EdgeInsets.only(left: 15.0, right: 15.0, bottom: 30.0, top: 15.0),
+          child: Container(
+            child: SingleChildScrollView(
+              child: Column(
+                children: <Widget>[
                   SizedBox(
-                  height: 20.0,
+                    height: 20.0,
                   ),
-
-                    TextFormField(
-                    controller: nombreApellidosText,
+                  TextFormField(
+                    controller: nombreText,
                     enabled: editable,
                     maxLines: 1,
                     keyboardType: TextInputType.text,
@@ -86,19 +84,16 @@ class PerfilUsuarioViewState extends State<PerfilUsuarioView> {
                       icon: Icon(Icons.person),
                       hintText: 'Introduce tu nombre y apellidos',
                       labelText: 'NOMBRE Y APELLIDOS',
-
                     ),
                   ),
-
                   SizedBox(
-                  height: 20.0,
+                    height: 20.0,
                   ),
-
                   TextFormField(
-                    controller: correoText,
+                    controller: nicknameText,
                     enabled: editable,
                     maxLines: 1,
-                    keyboardType: TextInputType.emailAddress,
+                    keyboardType: TextInputType.text,
                     autofocus: false,
                     style: TextStyle(color: TransportifyColors.primarySwatch),
                     maxLength: 50,
@@ -106,22 +101,17 @@ class PerfilUsuarioViewState extends State<PerfilUsuarioView> {
                       if (value.isEmpty) {
                         return 'El valor no puede estar vacío';
                       }
-                      if (!_isEmailCorrectlyFormed(value)) {
-                        return 'El formato es invalido';
-                      }
                       return null;
                     },
                     decoration: InputDecoration(
-                      icon: Icon(Icons.mail_outline),
-                      hintText: 'Introduce tu correo',
-                      labelText: 'CORREO',
+                      icon: Icon(Icons.person_outline),
+                      hintText: 'Introduce tu nombre de usuario',
+                      labelText: 'USUARIO',
                     ),
                   ),
-
                   SizedBox(
-                  height: 20.0,
+                    height: 20.0,
                   ),
-
                   TextFormField(
                     controller: ciudadText,
                     enabled: editable,
@@ -151,11 +141,9 @@ class PerfilUsuarioViewState extends State<PerfilUsuarioView> {
                       labelText: 'CIUDAD',
                     ),
                   ),
-
                   SizedBox(
-                  height: 20.0,
+                    height: 20.0,
                   ),
-                  
                   TextFormField(
                     controller: edadText,
                     enabled: editable,
@@ -169,7 +157,7 @@ class PerfilUsuarioViewState extends State<PerfilUsuarioView> {
                       if (soloNumeros == null) {
                         return 'El valor no puede estar vacío';
                       }
-                      if(soloNumeros < 18 || soloNumeros > 99) {
+                      if (soloNumeros < 18 || soloNumeros > 99) {
                         return 'Edad incorrecta';
                       }
                       return null;
@@ -180,15 +168,12 @@ class PerfilUsuarioViewState extends State<PerfilUsuarioView> {
                       labelText: 'EDAD',
                     ),
                   ),
-
                   SizedBox(
-                  height: 20.0,
+                    height: 20.0,
                   ),
-
                   Row(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: <Widget>[
-
                       RaisedButton(
                         color: colorGuardarCambios,
                         textColor: Colors.white,
@@ -200,27 +185,31 @@ class PerfilUsuarioViewState extends State<PerfilUsuarioView> {
                           borderRadius: BorderRadius.all(Radius.circular(10.0)),
                         ),
                         onPressed: () {
-                          setState(() {
-                            if(_formKey.currentState.validate()) {
-                              if(editable) {
+                          setState(() async {
+                            if (_formKey.currentState.validate()) {
+                              if (await UsuarioBD.existeUsuarioConNickname(
+                                  nicknameText.text)) {
+                                Toast.show(
+                                    "Error: El nombre de usuario está en uso. Elija otro.",
+                                    context,
+                                    duration: Toast.LENGTH_LONG,
+                                    gravity: Toast.BOTTOM);
+                              } else if (editable) {
                                 cambiarColorEditable();
                                 guardarCambios();
                                 editable = false;
                               }
                             }
-                          }
-                        );
-                      },
+                          });
+                        },
                         child: Text(
                           "Guardar cambios",
                           style: TextStyle(fontSize: 20.0),
                         ),
                       ),
-
                       SizedBox(
                         width: 20.0,
                       ),
-
                       RaisedButton(
                         color: Colors.red,
                         textColor: Colors.white,
@@ -234,36 +223,32 @@ class PerfilUsuarioViewState extends State<PerfilUsuarioView> {
                         onPressed: () {
                           setState(() {
                             showDialogBorrarPerfil();
-                          }
-                        );
-                      },
+                          });
+                        },
                         child: Text(
                           "Borrar perfil",
                           style: TextStyle(fontSize: 20.0),
                         ),
                       ),
-
                     ],
                   ),
-                  
                 ],
-              ),
               ),
             ),
           ),
+        ),
       ),
     );
-    
   }
 
   void cambiarColorEditable() {
-    if(editable) {
-      colorEditar = Colors.grey; 
-      colorGuardarCambios = Colors.grey; 
+    if (editable) {
+      colorEditar = Colors.grey;
+      colorGuardarCambios = Colors.grey;
       colorInternoGuardarCambios = Colors.grey;
     } else {
-      colorEditar = Colors.lightBlueAccent; 
-      colorGuardarCambios = TransportifyColors.primarySwatch; 
+      colorEditar = Colors.lightBlueAccent;
+      colorGuardarCambios = TransportifyColors.primarySwatch;
       colorInternoGuardarCambios = Colors.blueAccent;
     }
   }
@@ -279,7 +264,6 @@ class PerfilUsuarioViewState extends State<PerfilUsuarioView> {
             borderRadius: BorderRadius.all(Radius.circular(10.0)),
           ),
           actions: <Widget>[
-
             new FlatButton(
               color: TransportifyColors.primarySwatch,
               textColor: Colors.white,
@@ -291,10 +275,10 @@ class PerfilUsuarioViewState extends State<PerfilUsuarioView> {
                 Navigator.of(context).pop();
                 print("Perfil eliminado");
                 widget.usuario.deleteFromBD();
-                
-                Navigator.of(context)
-                .pushReplacement(MaterialPageRoute<Null>(builder: (BuildContext context) {
-                return new IniciarSesionView();
+
+                Navigator.of(context).pushReplacement(
+                    MaterialPageRoute<Null>(builder: (BuildContext context) {
+                  return new IniciarSesionView();
                 }));
 
                 /*
@@ -306,7 +290,6 @@ class PerfilUsuarioViewState extends State<PerfilUsuarioView> {
                 */
               },
             ),
-
             new FlatButton(
               color: TransportifyColors.primarySwatch,
               textColor: Colors.white,
@@ -318,7 +301,6 @@ class PerfilUsuarioViewState extends State<PerfilUsuarioView> {
                 Navigator.of(context).pop();
               },
             ),
-
           ],
         );
       },
@@ -326,35 +308,31 @@ class PerfilUsuarioViewState extends State<PerfilUsuarioView> {
   }
 
   void guardarCambios() {
-    widget.usuario.nombre = nombreApellidosText.text;
-    widget.usuario.correo = correoText.text;
+    widget.usuario.nombre = nombreText.text;
+    widget.usuario.nickname = nicknameText.text;
     widget.usuario.ciudad = ciudadText.text;
     widget.usuario.edad = int.parse(edadText.text);
     widget.usuario.updateBD();
-  }
 
-  bool _isEmailCorrectlyFormed(String email) {
-    return RegExp(
-            r"^[a-zA-Z0-9.a-zA-Z0-9.!#$%&'*+-/=?^_`{|}~]+@[a-zA-Z0-9]+\.[a-zA-Z]+")
-        .hasMatch(email);
+    Toast.show("Los datos han sido actualizados", context,
+        duration: Toast.LENGTH_LONG, gravity: Toast.BOTTOM);
   }
 
   @override
   void initState() {
     super.initState();
-    nombreApellidosText.text = widget.usuario.nombre;
-    correoText.text = widget.usuario.correo;
+    nombreText.text = widget.usuario.nombre;
+    nicknameText.text = widget.usuario.nickname;
     ciudadText.text = widget.usuario.ciudad;
     edadText.text = widget.usuario.edad.toString();
   }
 
   @override
   void dispose() {
-    nombreApellidosText.dispose();
-    correoText.dispose();
+    nombreText.dispose();
+    nicknameText.dispose();
     ciudadText.dispose();
     edadText.dispose();
     super.dispose();
   }
-  
 }


### PR DESCRIPTION
En ajustes de perfil, el correo del usuario no se puede modificar. De hecho, no se almacena en la base de datos (lo almacena el sistema de auth).

Sin embargo, en la ventana de ajustes de perfil, actualmente hay un apartado para el correo (que, como no guardamos copia del valor en la base de datos, no podemos rellenar. Además, modificarlo en la base de datos no tendría efecto, porque el sistema de auth tiene otra copia de sólo lectura).


Además, el nickname es, en esencia, un dato modificable. Pero no aparece en la ventana de ajustes de perfil.

Por tanto, tendría más sentido eliminar el dato de correo de la ventana, y sustituirlo por el nickname (nombre de usuario).


Por otro lado, el nombre de usuario debería ser único por usuario (ahora no lo es).